### PR TITLE
Updated Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ The steps to deploy (at a high level) are:
     1. `pipenv install gunicorn` - the webserver for Heroku to use (rather than the one built-in to Django)
     2. `pipenv install psycopg2-binary` - PostgreSQL client binaries
     3. `pipenv install dj-database-url` - enables parameterizing the database connection (so Heroku uses PostgreSQL but local is still SQLite)
-    4. `pipenv install python-decouple` - set important/secret values as environment variables
-    5. `pipenv install whitenoise` - optimizes deployment of static files (you may not have any, but it's good to add this now)
-    6. If using `virtualenv`, you need to create a `requirements.txt` file in your project root directory with the command: `pip freeze > requirements.txt`
+    4. `pipenv install whitenoise` - optimizes deployment of static files (you may not have any, but it's good to add this now)
+    5. If using `virtualenv`, you need to create a `requirements.txt` file in your project root directory with the command: `pip freeze > requirements.txt`
 6. Prepare your project
     1. Copy the `dotenv` file in this repository to `.env` in your repository (this should *not* be checked in)
     2. `ALLOWED_HOSTS` and `DATABASE_URL` are probably already correct for your local environment, but read/understand them
     3. Use the example code (you can just run it in a `python` repl) to generate a new secret key and change `SECRET_KEY`
-    4. `djorg/settings.py` will need new imports (`from decouple import config` and `import dj_database_url`)
+    4. `djorg/settings.py` will need new imports (`import dj_database_url`)
     5. You can use `config` to load the environment variables you set above, e.g. `SECRET_KEY = config('SECRET_KEY')` (`ALLOWED_HOSTS` will be a little trickier, but that's why this is a sprint challenge!)
     6. For the database, you want to both load the `DATABASE_URL` and pass it to `dj_database_url.config` (see [documentation](https://github.com/kennethreitz/dj-database-url))
     7. Make a `Procfile` ([example](https://github.com/heroku/python-getting-started/blob/master/Procfile)) to tell Heroku what to run to start your app. (Hint: the name of your Django project is probably "djorg", not "gettingstarted".)


### PR DESCRIPTION
Python-decouple was already part of the instructions within the 'Intro-to-Django' repository. 
Arguable you could also remove everything about the .env file.

IF it is left in for students that haven't reached that part of the initial repo yet, it would be good to mark it that way.